### PR TITLE
修复划线查询时，仍可以在小弹窗里划线的bug

### DIFF
--- a/src/javascript/selection.js
+++ b/src/javascript/selection.js
@@ -354,6 +354,12 @@
     var queryEvent = function (event) {
         //console.log("[ChaZD] current useCtrl: " + useCtrl);
         if (noSelect) {return;}
+        for (var name in classNameCollection) {
+            if (event.target.classList.contains(classNameCollection[name])) {
+                //console.log("[ChaZD] don't remove");
+                return;
+            }
+        }
         if (useCtrl) {
             //console.log("current togglekey: " + toggleKey);
             if (toggleKey === "ctrl") {


### PR DESCRIPTION
HI，
   这个翻译插件很赞，但我在使用时发现在划线查询时，仍可以在小弹窗里划线，导致无限弹窗，截图如下。
![bug](https://cloud.githubusercontent.com/assets/7080810/10069543/75decb2a-62df-11e5-93f3-1238bc7c566f.png)
